### PR TITLE
More compatibility with bibtex/natbib rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,301 @@
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# TeXnicCenter
+*.tps
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz
+
+# xwatermark package
+*.xwm
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib
+
+*.aux.make
+*.auxbbl.make
+*.auxtarget.make
+*.d
+*.out.make
+*.pag
+*.pdf
+*.lof.make
+*.lol.make
+*.toc.make
+*.bbl.cookie
+*.pdf.1st.make
+*.run.cookie
+*.auxbbl.make.temp
+*.lot.make
+*.vtc

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 TEXS = $(wildcard main-acm*.tex)
 PDFS = $(patsubst %.tex,%.pdf,$(TEXS))
+PDFLATEX = texfot pdflatex
 
 all: $(PDFS) main-bibtex.pdf
 
 main-bibtex.pdf: main-bibtex.tex
-	pdflatex $<
+	$(PDFLATEX) $<
 	bibtex main-bibtex
-	pdflatex $<
-	pdflatex $<
+	$(PDFLATEX) $<
+	$(PDFLATEX) $<
 
 %.pdf: %.tex
-	pdflatex $<
+	$(PDFLATEX) $<
 	biber $*
-	pdflatex $<
-	pdflatex $<
+	$(PDFLATEX) $<
+	$(PDFLATEX) $<
 
 clean:
-	echo "rm -f main{-acm*,-bibtex}.{bbl,blg,aux,log,out,bcf,run.xml} comment.cut *~" | bash
+	echo "rm -f main{-acm*,-bibtex}.{bbl,blg,aux,log,out,bcf,run.xml,pdf} comment.cut *~" | bash

--- a/acmauthoryear.cbx
+++ b/acmauthoryear.cbx
@@ -2,6 +2,75 @@
 
 \RequireCitationStyle{authoryear}
 
+% From https://tex.stackexchange.com/a/537666/133551
+\renewbibmacro*{cite}{%
+  \printtext[bibhyperref]{%
+    \iffieldundef{shorthand}
+      {\ifthenelse{\ifnameundef{labelname}\OR\iffieldundef{labelyear}}
+         {\usebibmacro{cite:label}%
+          \setunit{\printdelim{nonameyeardelim}}}
+         {\printnames{labelname}%
+          \setunit{\printdelim{nameyeardelim}}}%
+       \usebibmacro{cite:labeldate+extradate}}
+      {\usebibmacro{cite:shorthand}}}}
+
+\renewbibmacro*{citeyear}{%
+  \printtext[bibhyperref]{%
+    \iffieldundef{shorthand}
+      {\iffieldundef{labelyear}
+         {\usebibmacro{cite:label}}
+         {\usebibmacro{cite:labeldate+extradate}}}
+      {\usebibmacro{cite:shorthand}}}}
+
+\renewbibmacro*{textcite}{%
+  \ifnameundef{labelname}
+    {\iffieldundef{shorthand}
+       {\printtext[bibhyperref]{%
+          \usebibmacro{cite:label}}%
+        \setunit{%
+          \global\booltrue{cbx:parens}%
+          \printdelim{nonameyeardelim}\bibopenbracket}%
+        \ifnumequal{\value{citecount}}{1}
+          {\usebibmacro{prenote}}
+          {}%
+        \printtext[bibhyperref]{\usebibmacro{cite:labeldate+extradate}}}
+       {\printtext[bibhyperref]{\usebibmacro{cite:shorthand}}}}
+    {\printtext[bibhyperref]{\printnames{labelname}}%
+     \setunit{%
+       \global\booltrue{cbx:parens}%
+       \printdelim{nameyeardelim}\bibopenbracket}%
+     \ifnumequal{\value{citecount}}{1}
+       {\usebibmacro{prenote}}
+       {}%
+     \usebibmacro{citeyear}}}
+
+\renewbibmacro*{cite:shorthand}{%
+  \printfield{shorthand}}
+
+\renewbibmacro*{cite:label}{%
+  \iffieldundef{label}
+    {\printfield[citetitle]{labeltitle}}
+    {\printfield{label}}}
+
+\renewbibmacro*{cite:labeldate+extradate}{%
+  \printlabeldateextra}
+
+% NEW
+\newbibmacro*{citeauthor}{%
+  \ifnameundef{labelname}
+    {\iffieldundef{shorthand}
+      {\printtext[bibhyperref]{%
+          \usebibmacro{cite:label}}%
+        \setunit{%
+          \global\booltrue{cbx:parens}%
+          \printdelim{nonameyeardelim}\bibopenbracket}%
+        \ifnumequal{\value{citecount}}{1}
+          {\usebibmacro{prenote}}
+          {}%
+        \printtext[bibhyperref]{\usebibmacro{cite:labeldate+extradate}}}
+      {\printtext[bibhyperref]{\usebibmacro{cite:shorthand}}}}
+    \printtext[bibhyperref]{\printnames{labelname}}}
+
 %
 % Put brackets around citations
 %
@@ -69,5 +138,26 @@
   {\usebibmacro{textcite:postnote}}
 
 \DeclareMultiCiteCommand{\textcites}{\textcite}{}
+
+\DeclareCiteCommand{\citeauthor}
+  {\usebibmacro{prenote}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{citeauthor}}
+  {\multicitedelim}
+  {\usebibmacro{postnote}}
+
+\DeclareCiteCommand{\citeyear}
+  {\usebibmacro{prenote}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{citeyear}}
+  {\multicitedelim}
+  {\usebibmacro{postnote}}
+
+\DeclareCiteCommand{\citeyearpar}[\mkbibbrackets]
+  {\usebibmacro{prenote}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{citeyear}}
+  {\multicitedelim}
+  {\usebibmacro{postnote}}
 
 \endinput

--- a/acmauthoryear.cbx
+++ b/acmauthoryear.cbx
@@ -27,7 +27,7 @@
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkbibparens]
+\DeclareCiteCommand*{\parencite}[\mkbibbrackets]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}

--- a/main-acmauthoryear.tex
+++ b/main-acmauthoryear.tex
@@ -181,6 +181,8 @@ Text of abstract \ldots.
 
 Test brackets:~\cite{gf-tag-sound-repo,ad-wood-2003}\\
 Test repeated items:~\cite{897367,Buss:1987:VTB:897367}\\
+Test brackets*:~\cite*{gf-tag-sound-repo,ad-wood-2003}\\
+Test repeated items*:~\cite*{897367,Buss:1987:VTB:897367}\\
 Test citep: ~\citep{ad-wood-2003}\\
 Test citeauthor: ~\citeauthor{ad-wood-2003}\\
 Test citeyear: ~\citeyear{ad-wood-2003}\\

--- a/main-bibtex.tex
+++ b/main-bibtex.tex
@@ -175,6 +175,8 @@ Text of abstract \ldots.
 
 Test brackets:~\cite{gf-tag-sound-repo,ad-wood-2003}\\
 Test repeated items:~\cite{897367,Buss:1987:VTB:897367}\\
+Test brackets*:~\cite*{gf-tag-sound-repo,ad-wood-2003}\\
+Test repeated items*:~\cite*{897367,Buss:1987:VTB:897367}\\
 Test citep: ~\citep{ad-wood-2003}\\
 Test citeauthor: ~\citeauthor{ad-wood-2003}\\
 Test citeyear: ~\citeyear{ad-wood-2003}\\

--- a/sample-base.bib
+++ b/sample-base.bib
@@ -1586,35 +1586,6 @@ pages = "24--31"}
  lastaccessed = {May 27, 2019}
 }
 
-@Eprint{Bornmann2019,
-       author = {Bornmann, Lutz and Wray, K. Brad and Haunschild,
-                  Robin},
-        title = {Citation concept analysis {(CCA)}---A new form of
-                  citation analysis revealing the usefulness of
-                  concepts for other researchers illustrated by two
-                  exemplary case studies including classic books by
-                  {Thomas S.~Kuhn} and {Karl R.~Popper}},
-     keywords = {Computer Science - Digital Libraries},
-         year = 2019,
-        month = "May",
-          eid = {arXiv:1905.12410},
-archivePrefix = {arXiv},
-       eprint = {1905.12410},
- primaryClass = {cs.DL},
-}
-
-@Eprint{AnzarootPBM14,
-  author    = {Sam Anzaroot and
-               Alexandre Passos and
-               David Belanger and
-               Andrew McCallum},
-  title     = {Learning Soft Linear Constraints with Application to
-                  Citation Field Extraction},
-  year      = {2014},
-  archivePrefix = {arXiv},
-  eprint    = {1403.1349},
-}
-
 @inproceedings{Hagerup1993,
 title        = {Maintaining Discrete Probability Distributions Optimally},
 author       = {Hagerup, Torben and Mehlhorn, Kurt and Munro, J. Ian},


### PR DESCRIPTION
List of changes:
- Add .gitignore, hide unnecessary tex output
- I noticed `\parencite*` had a different behavior without the change `\DeclareCiteCommand*{\parencite}[\mkbibbrackets]`
- Added macros for `citeauthor`, `citeyear`, `citeyearpar` building upon solution 2 (see next comment).
- `\cite*` tests in both biblatex and bibtex authoryear files
- remove erroneous `@eprint` entries