### PR TITLE
Switch to authoryear-comp for compact citations

### DIFF
--- a/acmauthoryear.bbx
+++ b/acmauthoryear.bbx
@@ -1,7 +1,7 @@
 \ProvidesFile{acmauthoryear.bbx}[2022-02-14 v0.1 biblatex bibliography style]
 
 % Inherit a default style
-\RequireBibliographyStyle{authoryear}
+\RequireBibliographyStyle{authoryear-comp}
 
 %%% New command definitions from trad-standard.bbx
 
@@ -25,7 +25,7 @@
       Please consider updating your version of biblatex.\MessageBreak
       Using 'date+extrayear' instead}%
     \providebibmacro*{date+extradate}{\usebibmacro{date+extrayear}}
-    }{}  
+    }{}
   }
 
 %%% Localisation strings for ACM
@@ -849,7 +849,7 @@
      \step[typesource=artifactdataset,typetarget=dataset]
    }
   }
-}     
+}
 
 %%% Compatibility with ACM bibtex formatting
 
@@ -873,7 +873,7 @@
 }{%
   \newblock\setunit*{.\space}%
   \printtext%
-}{}{} 
+}{}{}
 
 
 %%% Set option values for ACM style

--- a/acmauthoryear.cbx
+++ b/acmauthoryear.cbx
@@ -1,62 +1,107 @@
 \ProvidesFile{acmauthoryear.cbx}[2022-02-14 v0.1]
 
-\RequireCitationStyle{authoryear}
+\RequireCitationStyle{authoryear-comp}
+\RequirePackage{xpatch}
 
 %
 % Hyperlink citations like acmart natbib implementation
 %
-% From https://tex.stackexchange.com/a/537666/133551
-\renewbibmacro*{cite}{%
-  \printtext[bibhyperref]{%
-    \iffieldundef{shorthand}
-      {\ifthenelse{\ifnameundef{labelname}\OR\iffieldundef{labelyear}}
-         {\usebibmacro{cite:label}%
-          \setunit{\printdelim{nonameyeardelim}}}
-         {\printnames{labelname}%
-          \setunit{\printdelim{nameyeardelim}}}%
-       \usebibmacro{cite:labeldate+extradate}}
-      {\usebibmacro{cite:shorthand}}}}
+% From https://tex.stackexchange.com/a/27615/133551
 
-\renewbibmacro*{citeyear}{%
-  \printtext[bibhyperref]{%
-    \iffieldundef{shorthand}
-      {\iffieldundef{labelyear}
-         {\usebibmacro{cite:label}}
-         {\usebibmacro{cite:labeldate+extradate}}}
-      {\usebibmacro{cite:shorthand}}}}
+% Combine label and labelyear links
+\xpatchbibmacro{cite}
+  {\usebibmacro{cite:label}%
+   \setunit{\printdelim{nonameyeardelim}}%
+   \usebibmacro{cite:labeldate+extradate}}
+  {\printtext[bibhyperref]{%
+     \DeclareFieldAlias{bibhyperref}{default}%
+     \usebibmacro{cite:label}%
+     \setunit{\printdelim{nonameyeardelim}}%
+     \usebibmacro{cite:labeldate+extradate}}}
+  {}
+  {\PackageWarning{biblatex-patch}
+     {Failed to patch cite bibmacro}}
+
+% Include labelname in labelyear link
+\xpatchbibmacro{cite}
+  {\printnames{labelname}%
+   \setunit{\printdelim{nameyeardelim}}%
+   \usebibmacro{cite:labeldate+extradate}}
+  {\printtext[bibhyperref]{%
+     \DeclareFieldAlias{bibhyperref}{default}%
+     \printnames{labelname}%
+     \setunit{\printdelim{nameyeardelim}}%
+     \usebibmacro{cite:labeldate+extradate}}}
+  {}
+  {\PackageWarning{biblatex-patch}
+     {Failed to patch cite bibmacro}}
 
 \renewbibmacro*{textcite}{%
-  \ifnameundef{labelname}
+  \iffieldequals{namehash}{\cbx@lasthash}
     {\iffieldundef{shorthand}
-       {\printtext[bibhyperref]{%
-          \usebibmacro{cite:label}}%
+       {\ifthenelse{\iffieldequals{labelyear}{\cbx@lastyear}\AND
+                    \(\value{multicitecount}=0\OR\iffieldundef{postnote}\)}
+          {\setunit{\addcomma}%
+           \usebibmacro{cite:extradate}}
+          {\setunit{\compcitedelim}%
+           \usebibmacro{cite:labeldate+extradate}%
+           \savefield{labelyear}{\cbx@lastyear}}}
+       {\setunit{\compcitedelim}%
+        \usebibmacro{cite:shorthand}%
+        \global\undef\cbx@lastyear}}
+    {\ifnameundef{labelname}
+       {\iffieldundef{shorthand}
+          {\usebibmacro{cite:label}%
+           \setunit{%
+             \global\booltrue{cbx:parens}%
+             \printdelim{nonameyeardelim}\bibopenbracket}%
+           \ifnumequal{\value{citecount}}{1}
+             {\usebibmacro{prenote}}
+             {}%
+           \usebibmacro{cite:labeldate+extradate}}
+          {\usebibmacro{cite:shorthand}}}
+       {\printnames{labelname}%
         \setunit{%
           \global\booltrue{cbx:parens}%
-          \printdelim{nonameyeardelim}\bibopenbracket}%
+          \printdelim{nameyeardelim}\bibopenbracket}%
         \ifnumequal{\value{citecount}}{1}
           {\usebibmacro{prenote}}
           {}%
-        \printtext[bibhyperref]{\usebibmacro{cite:labeldate+extradate}}}
-       {\printtext[bibhyperref]{\usebibmacro{cite:shorthand}}}}
-    {\printtext[bibhyperref]{\printnames{labelname}}%
-     \setunit{%
-       \global\booltrue{cbx:parens}%
-       \printdelim{nameyeardelim}\bibopenbracket}%
-     \ifnumequal{\value{citecount}}{1}
-       {\usebibmacro{prenote}}
-       {}%
-     \usebibmacro{citeyear}}}
+        \iffieldundef{shorthand}
+          {\iffieldundef{labelyear}
+             {\usebibmacro{cite:label}}
+             {\usebibmacro{cite:labeldate+extradate}}%
+           \savefield{labelyear}{\cbx@lastyear}}
+          {\usebibmacro{cite:shorthand}%
+           \global\undef\cbx@lastyear}}%
+     \stepcounter{textcitecount}%
+     \savefield{namehash}{\cbx@lasthash}}%
+  \setunit{%
+    \ifbool{cbx:parens}
+      {\bibclosebracket\global\boolfalse{cbx:parens}}
+      {}%
+    \textcitedelim}}
 
-\renewbibmacro*{cite:shorthand}{%
-  \printfield{shorthand}}
+\xpatchbibmacro{textcite}
+  {\printnames{labelname}}
+  {\printtext[bibhyperref]{\printnames{labelname}}}
+  {}
+  {\PackageWarning{biblatex-patch}
+     {Failed to patch textcite bibmacro}}
 
-\renewbibmacro*{cite:label}{%
-  \iffieldundef{label}
-    {\printfield[citetitle]{labeltitle}}
-    {\printfield{label}}}
-
-\renewbibmacro*{cite:labeldate+extradate}{%
-  \printlabeldateextra}
+\renewbibmacro*{textcite:postnote}{%
+  \usebibmacro{postnote}%
+  \ifthenelse{\value{multicitecount}=\value{multicitetotal}}
+    {\setunit{}%
+     \printtext{%
+       \ifbool{cbx:parens}
+         {\bibclosebracket\global\boolfalse{cbx:parens}}
+         {}}}
+    {\setunit{%
+       \ifbool{cbx:parens}
+         {\bibclosebracket\global\boolfalse{cbx:parens}}
+         {}%
+       \textcitedelim}}}
 
 % NEW
 \newbibmacro*{citeauthor}{%
@@ -74,105 +119,94 @@
       {\printtext[bibhyperref]{\usebibmacro{cite:shorthand}}}}
     \printtext[bibhyperref]{\printnames{labelname}}}
 
-\renewbibmacro*{textcite:postnote}{%
-  \iffieldundef{postnote}
-    {\ifbool{cbx:parens}
-       {\bibclosebracket}
-       {}}
-    {\ifbool{cbx:parens}
-       {\setunit{\printdelim{postnotedelim}}}
-       {\setunit{\printdelim{extpostnotedelim}\bibopenbracket}}%
-     \printfield{postnote}\bibclosebracket}}
-
 %
 % Put brackets around citations
 %
 
 \DeclareCiteCommand{\cite}[\mkbibbrackets]
-  {\usebibmacro{prenote}}%
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand*{\cite}[\mkbibbrackets]
-  {\usebibmacro{prenote}}%
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand{\parencite}[\mkbibbrackets]
-  {\usebibmacro{prenote}}%
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand*{\parencite}[\mkbibbrackets]
-  {\usebibmacro{prenote}}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
-\DeclareMultiCiteCommand{\parencites}[\mkbibbrackets]{\parencite}{\multicitedelim}
+\DeclareMultiCiteCommand{\parencites}[\mkbibbrackets]{\parencite}
+  {\setunit{\multicitedelim}}
 
 \DeclareCiteCommand{\footcite}[\mkbibfootnote]
-  {\usebibmacro{prenote}}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand{\footcitetext}[\mkbibfootnotetext]
-  {\usebibmacro{prenote}}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand{\smartcite}[\iffootnote\mkbibbrackets\mkbibfootnote]
-  {\usebibmacro{prenote}}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\textcite}
-  {\boolfalse{cbx:parens}}
-  {\usebibmacro{citeindex}%
-   \iffirstcitekey
-     {\setcounter{textcitetotal}{1}}
-     {\stepcounter{textcitetotal}%
-      \textcitedelim}%
-   \usebibmacro{textcite}}
-  {\ifbool{cbx:parens}
-     {\bibclosebracket\global\boolfalse{cbx:parens}}
-     {}}
-  {\usebibmacro{textcite:postnote}}
-
-\DeclareMultiCiteCommand{\textcites}{\textcite}{}
+\DeclareMultiCiteCommand{\smartcites}[\iffootnote\mkbibbrackets\mkbibfootnote]
+  {\smartcite}{\setunit{\multicitedelim}}
 
 \DeclareCiteCommand{\citeauthor}
-  {\usebibmacro{prenote}}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeauthor}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand{\citeyear}
-  {\usebibmacro{prenote}}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand{\citeyearpar}[\mkbibbrackets]
-  {\usebibmacro{prenote}}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
-  {\multicitedelim}
+  {}
   {\usebibmacro{postnote}}
 
 %

--- a/main-acmauthoryear.tex
+++ b/main-acmauthoryear.tex
@@ -183,11 +183,12 @@ Test brackets:~\cite{gf-tag-sound-repo,ad-wood-2003}\\
 Test repeated items:~\cite{897367,Buss:1987:VTB:897367}\\
 Test brackets*:~\cite*{gf-tag-sound-repo,ad-wood-2003}\\
 Test repeated items*:~\cite*{897367,Buss:1987:VTB:897367}\\
+Test citep: ~\citep{ad-wood-2003}\\
 Test citeauthor: ~\citeauthor{ad-wood-2003}\\
 Test citeyear: ~\citeyear{ad-wood-2003}\\
 Test citeyearpar: ~\citeyearpar{ad-wood-2003}\\
-Test textcite: ~\textcite{ad-wood-2003}\\
-Test textcite multiple: ~\textcite{ad-wood-2003,897367,Buss:1987:VTB:897367}\\
+Test citet (textcite): ~\citet{ad-wood-2003}\\
+Test citet (textcite) multiple: ~\citet{ad-wood-2003,897367,Buss:1987:VTB:897367}\\
 
 \subsubsection{More BibLaTeX Tests}
 


### PR DESCRIPTION
It's ready!

Here's the output comparison:

1. bibtex
<img width="531" alt="Screen Shot 2022-02-28 at 10 53 46 AM" src="https://user-images.githubusercontent.com/374340/156024469-d40abfa4-d63c-4f80-bf7d-cb7a3257f82f.png">

2. biblatex
<img width="554" alt="Screen Shot 2022-02-28 at 10 54 09 AM" src="https://user-images.githubusercontent.com/374340/156024531-338e2135-68fc-4abe-ad20-79a86d8b35ba.png">

We should probably make note of the difference with biblatex with starred versions of the commands.
